### PR TITLE
GetAsync redirect handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -355,3 +355,6 @@ MigrationBackup/
 
 # Other
 /src/PackageUploader.Application/Properties/launchSettings.json
+
+# Intellij Rider
+.idea/

--- a/src/PackageUploader.ClientApi/Client/Ingestion/Client/HttpRestClient.cs
+++ b/src/PackageUploader.ClientApi/Client/Ingestion/Client/HttpRestClient.cs
@@ -55,11 +55,11 @@ internal abstract class HttpRestClient : IHttpRestClient
             if (response.StatusCode is HttpStatusCode.Redirect or HttpStatusCode.MovedPermanently or HttpStatusCode.Found 
                 or HttpStatusCode.SeeOther or HttpStatusCode.TemporaryRedirect)
             {
-                string redirectUrl = response.Headers.Location?.ToString();
+                string redirectUrl = response.Headers.Location?.AbsolutePath;
                 var redirectRequest = CreateJsonRequestMessage(HttpMethod.Get, redirectUrl);
 
                 await LogRequestVerboseAsync(redirectRequest, ct).ConfigureAwait(false);
-                using var redirectResponse = await _httpClient.SendAsync(request, ct).ConfigureAwait(false);
+                using var redirectResponse = await _httpClient.SendAsync(redirectRequest, ct).ConfigureAwait(false);
                 await LogResponseVerboseAsync(redirectResponse, ct).ConfigureAwait(false);
                 redirectResponse.EnsureSuccessStatusCode();
                 

--- a/src/PackageUploader.ClientApi/Client/Ingestion/Client/HttpRestClient.cs
+++ b/src/PackageUploader.ClientApi/Client/Ingestion/Client/HttpRestClient.cs
@@ -55,7 +55,7 @@ internal abstract class HttpRestClient : IHttpRestClient
             if (response.StatusCode is HttpStatusCode.Redirect or HttpStatusCode.MovedPermanently or HttpStatusCode.Found 
                 or HttpStatusCode.SeeOther or HttpStatusCode.TemporaryRedirect)
             {
-                string redirectUrl = response.Headers.Location?.AbsolutePath;
+                string redirectUrl = response.Headers.Location?.AbsoluteUri;
                 var redirectRequest = CreateJsonRequestMessage(HttpMethod.Get, redirectUrl);
 
                 await LogRequestVerboseAsync(redirectRequest, ct).ConfigureAwait(false);


### PR DESCRIPTION
Adding redirect handling for GetAsync method to fix observed behavior of GetAsync failing when a 301 response is generated when the packageId is changed after initial upload, but before symbols and additional files are  uploaded